### PR TITLE
Add a dot on the board at the next square position

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -93,6 +93,13 @@ export default function App() {
             onDrop={({ targetSquare }) => placeKnight(targetSquare)}
             onSquareClick={(square) => placeKnight(square)}
             position={puzzleState.position}
+            squareStyles={{
+              [puzzleState.nextSquare]: {
+                background:
+                  "radial-gradient(circle, #f6ca6b 36%, transparent 40%)",
+                borderRadius: "50%"
+              }
+            }}
           />
         </div>
         <StraightProgressIndicator {...progressIndicatorProps} />


### PR DESCRIPTION
Several commenters on [the recent Hacker News thread about this game](https://news.ycombinator.com/item?id=34460868) complained that the instructions were unclear and they weren't sure where they needed to move to progress through the game.

This update adds a yellow dot on the next square to make the next move clearer.